### PR TITLE
Add tests for wormholing into the head of the Ember app

### DIFF
--- a/tests/acceptance/wormhole-test.js
+++ b/tests/acceptance/wormhole-test.js
@@ -191,3 +191,34 @@ test('throws if destination element id falsy', function(assert) {
     );
   });
 });
+
+test('favicon example', function(assert) {
+  visit('/');
+  andThen(function () {
+    var favicon = $('link[rel="icon"]');
+    assert.equal(favicon.attr('href'), 'http://emberjs.com/images/favicon.png');
+  });
+
+  fillIn('.favicon', 'http://handlebarsjs.com/images/favicon.png');
+  andThen(function () {
+    var favicon = $('link[rel="icon"]');
+    assert.equal(favicon.attr('href'), 'http://handlebarsjs.com/images/favicon.png');
+  });
+});
+
+test('document-title example', function(assert) {
+  visit('/');
+  andThen(function () {
+    assert.equal(document.title, 'ember-wormhole');
+  });
+
+  click('#toggle-title');
+  andThen(function () {
+    assert.equal(document.title, 'ember-wormhole Testing');
+  });
+
+  click('#toggle-title');
+  andThen(function () {
+    assert.equal(document.title, 'ember-wormhole');
+  });
+});

--- a/tests/dummy/app/components/document-title.js
+++ b/tests/dummy/app/components/document-title.js
@@ -1,0 +1,23 @@
+import Ember from "ember";
+import Wormhole from 'ember-wormhole/components/ember-wormhole';
+
+var titles = Ember.A([]);
+export default Wormhole.extend({
+  init: function () {
+    this._super();
+
+    if (titles.length === 0) {
+      document.title = '';
+    }
+    titles.push(this);
+  },
+
+  destinationElement: Ember.computed(function () {
+    return document.getElementsByTagName('title')[0];
+  }),
+
+  willClearRender: function () {
+    titles.removeObject(this);
+    this._super.apply(this, arguments);
+  }
+});

--- a/tests/dummy/app/components/x-favicon.js
+++ b/tests/dummy/app/components/x-favicon.js
@@ -1,0 +1,8 @@
+import Ember from "ember";
+import Wormhole from 'ember-wormhole/components/ember-wormhole';
+
+export default Wormhole.extend({
+  destinationElement: Ember.computed(function () {
+    return document.getElementsByTagName('head')[0];
+  })
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,6 +7,8 @@ export default Ember.Controller.extend({
   isShowingSidebarContent: false,
   sidebarId: 'sidebar',
   isInPlace: false,
+  isTestingDocumentTitle: false,
+  favicon: "http://emberjs.com/images/favicon.png",
   actions: {
     toggleModal() {
       this.toggleProperty('isShowingModal');
@@ -20,6 +22,9 @@ export default Ember.Controller.extend({
     },
     toggleInPlace() {
       this.toggleProperty('isInPlace');
+    },
+    toggleTitle() {
+      this.toggleProperty('isTestingDocumentTitle');
     }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,11 @@
-<<h1 id="title">ember-wormhole</h1>
+{{x-favicon href=favicon}}
+
+{{#if isTestingDocumentTitle}}
+  {{#document-title}} Testing{{/document-title}}
+{{/if}}
+{{#document-title}}ember-wormhole{{/document-title}}
+
+<h1 id="title">ember-wormhole</h1>
 
 {{outlet}}
 
@@ -19,6 +26,16 @@
   <code>user</code> object and is used to demonstrate bound values across
   the wormhole boundary.
 </p>
+
+<p>
+  In addition to the visible wormholes on screen, there are components
+  that inject Ember into the <code>head</code> of the page.
+</p>
+
+<button id="toggle-title" {{action 'toggleTitle'}}>Toggle Title</button>
+<label>
+  Favicon: {{input value=favicon class="favicon"}}
+</label>
 
 <div class='example' id='example-modal'>
   <h2>Modal Example</h2>

--- a/tests/dummy/app/templates/components/x-favicon.hbs
+++ b/tests/dummy/app/templates/components/x-favicon.hbs
@@ -1,0 +1,1 @@
+<link rel="icon" {{bind-attr href=href}} />


### PR DESCRIPTION
And adding examples that apply to elements in the `<head>` of the documents.

The `x-favicon` example is a nudge at what apps like TravisCI does, and the `document-title` example is a simplistic version ripped from that addon I develop.

:3