### PR TITLE
Add ability to specify a wormhole destination that's not based on an ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ cache:
     - node_modules
 
 before_install:
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
@@ -27,6 +31,7 @@ env:
   - EMBER_TRY_SCENARIO="Ember Canary"
 
 matrix:
+  fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO="Ember Beta"
     - env: EMBER_TRY_SCENARIO="Ember Canary"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Similarly, if you use `ember-wormhole` in a route's template, it will
 render its children in the destination element when the route is entered
 and remove them when the route is exited.
 
+If you wish to render into an element that's not an id, you may do something likt his
+
+```hbs
+{{#if isWormholeEnabled}}
+  {{#ember-wormhole destinationElementSelector="#ember1337 .component-body"}}
+    Hello world!
+  {{/ember-wormhole}}
+{{/if}}
+```
+
 ## Can I Render In Place (i.e. Unwormhole)?
 
 Yes! Sometimes you feel like a wormhole. Sometimes you don't. Situations 
@@ -83,6 +93,31 @@ This technique is useful for:
 - Presenting typically-wormholed content within a styleguide
 - Toggling content back and forth through the wormhole
 - Parlor tricks
+
+## And what about selectors?
+
+Selectors that return more than one result will throw an error. For example, if we have
+
+```html
+...
+<div class="actor jason-spader"></div>
+<div class="actor kurt-russel"></div>
+```
+
+Then this would be fine
+
+```hbs
+{{#ember-wormhole destinationElementSelector=".jason-spader"}}
+ ...
+{{/ember-wormhole}}
+```
+but this would not
+
+```hbs
+{{#ember-wormhole destinationElementSelector=".actor"}}
+ ...
+{{/ember-wormhole}}
+```
 
 ## Development Setup
 

--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -7,8 +7,28 @@ var run = Ember.run;
 export default Ember.Component.extend({
   to: computed.alias('destinationElementId'),
   destinationElementId: null,
-  destinationElement: computed('destinationElementId', 'renderInPlace', function() {
-    return this.get('renderInPlace') ? this.element : document.getElementById(this.get('destinationElementId'));
+  destinationElementSelector: computed('destinationElementId', function() {
+    var destinationId = this.get('destinationElementId');
+    return destinationId ? `#${destinationId}` : null;
+  }),
+  destinationElement: computed('destinationElementSelector', 'renderInPlace', function() {
+    if (this.get('renderInPlace')) {
+      return this.element;
+    } else {
+      var sel = this.get('destinationElementSelector');
+      var results =  document.querySelectorAll(sel);
+      if (results.length > 1) {
+        throw new Error(`Selector ${sel} resulted in more than one element being found`);
+      }
+      else {
+        if (results.length === 0) {
+          return null;
+        }
+        else {
+          return results[0];
+        }
+      }
+    }
   }),
   renderInPlace: false,
 
@@ -36,11 +56,11 @@ export default Ember.Component.extend({
   appendToDestination: function() {
     var destinationElement = this.get('destinationElement');
     if (!destinationElement) {
-      var destinationElementId = this.get('destinationElementId');
-      if (destinationElementId) {
-        throw new Error(`ember-wormhole failed to render into '#${this.get('destinationElementId')}' because the element is not in the DOM`);
+      var destinationElementSelector = this.get('destinationElementSelector');
+      if (destinationElementSelector) {
+        throw new Error(`ember-wormhole failed to render into '${this.get('destinationElementSelector')}' because the element is not in the DOM`);
       }
-      throw new Error('ember-wormhole failed to render content because the destinationElementId was set to an undefined or falsy value.');
+      throw new Error('ember-wormhole failed to render content because the destinationElementSelector was set to an undefined or falsy value.');
     }
     this.appendRange(destinationElement, this._firstNode, this._lastNode);
   },

--- a/examples/modal2.hbs
+++ b/examples/modal2.hbs
@@ -1,0 +1,9 @@
+{{#if isShowingModal2}}
+  {{#ember-wormhole destinationElementSelector='#modals .modal2'}}
+    <div class="overlay" {{action 'toggleModal2'}}></div>
+    <div class="dialog">
+      <h1>Hi, I'm a simple modal dialog</h1>
+      <button {{action 'toggleModal2'}}>Close</button>
+    </div>
+  {{/ember-wormhole}}
+{{/if}}

--- a/tests/acceptance/wormhole-test.js
+++ b/tests/acceptance/wormhole-test.js
@@ -50,6 +50,23 @@ test('modal example', function(assert) {
   });
 });
 
+test('non-id-selector-based modal example', function(assert) {
+  visit('/');
+  andThen(function() {
+    assert.equal(currentPath(), 'index');
+  });
+  click('button:contains(Toggle Another Modal)');
+  andThen(function() {
+    assert.equal(Ember.$('.modal2 .overlay').length, 1, 'overlay is visible');
+    assert.equal(Ember.$('.modal2 .dialog').length, 1, 'dialog is visible');
+  });
+  click('.modal2 .overlay');
+  andThen(function() {
+    assert.equal(Ember.$('.modal2 .overlay').length, 0, 'overlay is not visible');
+    assert.equal(Ember.$('.modal2 .dialog').length, 0, 'dialog is not visible');
+  });
+});
+
 test('sidebar example', function(assert) {
   var sidebarWormhole;
   var header1, header2;
@@ -191,7 +208,7 @@ test('throws if destination element id falsy', function(assert) {
   andThen(function() {
     assert.throws(
       wormholeToNowhere,
-      /ember-wormhole failed to render content because the destinationElementId/,
+      /ember-wormhole failed to render content because the destinationElement/,
       'throws on missing destination element id'
     );
   });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -4,12 +4,16 @@ var set = Ember.set;
 
 export default Ember.Controller.extend({
   isShowingModal: false,
+  isShowingModal2: false,
   isShowingSidebarContent: false,
   sidebarId: 'sidebar',
   isInPlace: false,
   actions: {
     toggleModal() {
       this.toggleProperty('isShowingModal');
+    },
+    toggleModal2() {
+      this.toggleProperty('isShowingModal2');
     },
     toggleSidebarContent() {
       this.toggleProperty('isShowingSidebarContent');

--- a/tests/dummy/app/initializers/add-modals-element.js
+++ b/tests/dummy/app/initializers/add-modals-element.js
@@ -1,10 +1,21 @@
 /*globals document*/
 function initialize(container, application){
   var rootEl = document.querySelector(application.rootElement);
+
+  var existingModalsEl = document.getElementById('modals');
+
+  if (existingModalsEl) {
+    existingModalsEl.remove();
+  }
+
   var modalContainerEl = document.createElement('div');
   var modalContainerElId = 'modals';
   modalContainerEl.id = modalContainerElId;
   rootEl.appendChild(modalContainerEl);
+
+  var modal2ContainerEl = document.createElement('div');
+  modal2ContainerEl.className = 'modal2';
+  modalContainerEl.appendChild(modal2ContainerEl);
 }
 
 export default {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -66,3 +66,19 @@
     {{/if}}
   {{/current-user}}
 </div>
+
+<div class='example' id='class-example'>
+  <h2>Class Example</h2>
+  <button {{action 'toggleModal2'}}>Toggle Another Modal</button>
+
+    {{code-snippet name='modal2.hbs'}}
+    {{#if isShowingModal2}}
+      {{#ember-wormhole destinationElementSelector='#modals .modal2'}}
+        <div class="overlay" {{action 'toggleModal2'}}></div>
+        <div class="dialog">
+          <h1>Hi, I'm a simple modal dialog</h1>
+          <button {{action 'toggleModal2'}}>Close</button>
+        </div>
+      {{/ember-wormhole}}
+    {{/if}}
+</div>


### PR DESCRIPTION
I have a use case for a wormhole, where it's inconvenient to specify the destination element by ID. This PR should allow use of any valid selector, ultimately based on the result of 

```js
document.querySelector( ... );
```

`destinationElementId` (and via `alias`, `to`) take precedence in order to avoid breaking anything.