### PR TITLE
Updates for Ember 1.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,16 @@ script:
   - ./node_modules/.bin/ember try "$EMBER_TRY_SCENARIO" test
 
 env:
-  - EMBER_TRY_SCENARIO="Ember 1.10.0"
-  - EMBER_TRY_SCENARIO="Ember 1.11.3"
-  - EMBER_TRY_SCENARIO="Ember 1.12.0"
-  - EMBER_TRY_SCENARIO="Ember Beta"
-  - EMBER_TRY_SCENARIO="Ember Canary"
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=1.10.1
+  - EMBER_TRY_SCENARIO=1.11.3
+  - EMBER_TRY_SCENARIO=1.12.1
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
+  fast_finish: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO="Ember Beta"
-    - env: EMBER_TRY_SCENARIO="Ember Canary"
+    - env: EMBER_TRY_SCENARIO=ember-beta
+    - env: EMBER_TRY_SCENARIO=ember-canary

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-wormhole",
   "dependencies": {
-    "ember": "1.11.3",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,39 +1,52 @@
 module.exports = {
   scenarios: [
     {
-      name: 'Ember Canary',
+      name: 'default',
+      dependencies: { }
+    },
+    {
+      name: '1.10.1',
       dependencies: {
-        "ember": "components/ember#canary"
+        'ember': '1.10.1'
+      }
+    },
+    {
+      name: '1.11.3',
+      dependencies: {
+        'ember': '1.11.3'
+      }
+    },
+    {
+      name: '1.12.1',
+      dependencies: {
+        'ember': '1.12.1'
+      }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
       },
       resolutions: {
-        "ember": "canary"
+        'ember': 'release'
       }
     },
     {
-      name: 'Ember Beta',
+      name: 'ember-beta',
       dependencies: {
-        "ember": "components/ember#beta"
+        'ember': 'components/ember#beta'
       },
       resolutions: {
-        "ember": "beta"
+        'ember': 'beta'
       }
     },
     {
-      name: "Ember 1.12.0",
+      name: 'ember-canary',
       dependencies: {
-        "ember": "1.12.0"
-      }
-    },
-    {
-      name: "Ember 1.11.3",
-      dependencies: {
-        "ember": "1.11.3"
-      }
-    },
-    {
-      name: "Ember 1.10.0",
-      dependencies: {
-        "ember": "1.10.0"
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
       }
     }
   ]

--- a/tests/acceptance/wormhole-test.js
+++ b/tests/acceptance/wormhole-test.js
@@ -6,7 +6,7 @@ import {
 } from 'qunit';
 import startApp from 'dummy/tests/helpers/start-app';
 
-var application;
+var application, viewRegistry;
 var assert = QUnit.assert;
 
 assert.contentIn = function(sidebarId, content) {
@@ -21,6 +21,12 @@ assert.contentNotIn = function(sidebarId, content) {
 module('Acceptance: Wormhole', {
   beforeEach: function() {
     application = startApp();
+    viewRegistry = application.__container__.lookup('-view-registry:main');
+
+    // -view-registry:main is only available on 1.12+
+    if (!viewRegistry) {
+      viewRegistry = Ember.View.views;
+    }
   },
 
   afterEach: function() {
@@ -61,7 +67,7 @@ test('sidebar example', function(assert) {
   });
   click('button:contains(Toggle Sidebar Content)');
   andThen(function() {
-    sidebarWormhole = Ember.View.views.sidebarWormhole;
+    sidebarWormhole = viewRegistry.sidebarWormhole;
     sidebarFirstNode1 = sidebarWormhole._firstNode;
     header1 = Ember.$('#sidebar h1');
     assert.contentIn('sidebar');
@@ -139,7 +145,7 @@ test('survives rerender', function(assert) {
 
   click('button:contains(Toggle Sidebar Content)');
   andThen(function() {
-    sidebarWormhole = Ember.View.views.sidebarWormhole;
+    sidebarWormhole = viewRegistry.sidebarWormhole;
     sidebarFirstNode1 = sidebarWormhole._firstNode;
     header1 = Ember.$('#sidebar h1');
     assert.contentIn('sidebar');
@@ -160,8 +166,6 @@ test('survives rerender', function(assert) {
     header2 = Ember.$('#sidebar h1');
     assert.contentIn('sidebar', 'p:contains(Ringo Starr)');
     assert.equal(header1.text(), header2.text(), 'same header text');
-    assert.ok(!header1.is(header2), 'different header elements'); // rerendered
-    assert.ok(!sidebarFirstNode1.isSameNode(sidebarFirstNode2), 'different first nodes'); // rerendered
   });
 });
 


### PR DESCRIPTION
* Only use `Ember.View.views` as a fallback if `-view-registry:main` is not available.
* Remove assertion confirming that different elements are created upon `.rerender()` (a rerender in Ember 1.13 maintains the same element).
* Update ember-try configuration for 1.13.
  * Change scenario names to match the default ones added by ember-cli
    (and used by ember-modal-dialog/ember-tether)
  * Make 1.13 the default version.