### PR TITLE
fix issue when firstNode is the same as lastNode

### DIFF
--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -58,9 +58,12 @@ export default Ember.Component.extend({
       var next = node.previousSibling;
       if (node.parentNode) {
         node.parentNode.removeChild(node);
+        if (node === firstNode) {
+          break;
+        }
       }
       node = next;
-    } while (node !== firstNode);
+    } while (node);
   }
 
 });


### PR DESCRIPTION
closes #12 for me
I would an acceptance test for this bugfix but the test only fails if ember 1.13 is installed, and if I bump ember to 1.13 in the addon a few other tests fail as well so without fixing them I couldn't really test it.