### PR TITLE
Auto-generate destination element if none is specified.

### DIFF
--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -8,9 +8,19 @@ export default Ember.Component.extend({
   to: computed.alias('destinationElementId'),
   destinationElementId: null,
   destinationElement: computed('destinationElementId', 'renderInPlace', function() {
-    return this.get('renderInPlace') ? this.element : document.getElementById(this.get('destinationElementId'));
+    if (this.get('renderInPlace')) {
+      return this.element;
+    } else if (this.get('destinationElementId')) {
+      return document.getElementById(this.get('destinationElementId'));
+    } else {
+      this.set('shouldDestroyDestination', true);
+      var element = document.createElement('div');
+      document.body.appendChild(element);
+      return element;
+    }
   }),
   renderInPlace: false,
+  shouldDestroyDestination: false,
 
   didInsertElement: function() {
     this._firstNode = this.element.firstChild;
@@ -23,6 +33,12 @@ export default Ember.Component.extend({
     var lastNode = this._lastNode;
     run.schedule('render', () => {
       this.removeRange(firstNode, lastNode);
+      if (this.get('shouldDestroyDestination')) {
+        let destination = this.get('destinationElement');
+        if (destination && destination.parentNode) {
+          destination.parentNode.removeChild(destination);
+        }
+      }
     });
   },
 

--- a/tests/acceptance/wormhole-test.js
+++ b/tests/acceptance/wormhole-test.js
@@ -181,18 +181,3 @@ test('throws if destination element not in DOM', function(assert) {
     );
   });
 });
-
-test('throws if destination element id falsy', function(assert) {
-  visit('/');
-  var wormholeToNowhere = function() {
-    application.__container__.lookup('controller:application').set('sidebarId', null);
-    Ember.$('button:contains(Toggle Sidebar Content)').click();
-  };
-  andThen(function() {
-    assert.throws(
-      wormholeToNowhere,
-      /ember-wormhole failed to render content because the destinationElementId/,
-      'throws on missing destination element id'
-    );
-  });
-});


### PR DESCRIPTION
I'd like to use `ember-wormhole` for all sorts of things (popovers, dropdowns, modals, etc.). Would be awesome if specifying a `to` element was not required. If a `to` is not specified, a `<div>` is automatically created, appended to the `<body>` element, and used as the destination.
