### PR TITLE
fix export statement to be compatible with IE8

### DIFF
--- a/app/components/ember-wormhole.js
+++ b/app/components/ember-wormhole.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-wormhole/components/ember-wormhole';
+import EmberWormhole from 'ember-wormhole/components/ember-wormhole';
+
+export default EmberWormhole


### PR DESCRIPTION
This is very similar to issue [#311 in liquid fire](https://github.com/ef4/liquid-fire/issues/311). When using the `export { default } from...` it creates a parse error in IE8. This fixes the issue that I've found.