### PR TITLE
Preserve focus

### DIFF
--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -35,6 +35,7 @@ export default Ember.Component.extend({
 
   appendToDestination: function() {
     var destinationElement = this.get('destinationElement');
+    var currentActiveElement = document.activeElement;
     if (!destinationElement) {
       var destinationElementId = this.get('destinationElementId');
       if (destinationElementId) {
@@ -42,7 +43,11 @@ export default Ember.Component.extend({
       }
       throw new Error('ember-wormhole failed to render content because the destinationElementId was set to an undefined or falsy value.');
     }
+
     this.appendRange(destinationElement, this._firstNode, this._lastNode);
+    if (document.activeElement !== currentActiveElement) {
+      currentActiveElement.focus();
+    }
   },
 
   appendRange: function(destinationElement, firstNode, lastNode) {

--- a/tests/acceptance/wormhole-test.js
+++ b/tests/acceptance/wormhole-test.js
@@ -196,3 +196,20 @@ test('throws if destination element id falsy', function(assert) {
     );
   });
 });
+
+test('preserves focus', function (assert) {
+  var focused;
+  visit('/');
+  andThen(function() {
+    assert.equal(currentPath(), 'index');
+  });
+  click('button:contains(Toggle Sidebar Content)');
+  andThen(function() {
+    Ember.$('button:contains(Hide Sidebar Content)').focus();
+    focused = document.activeElement;
+  });
+  click('button:contains(Switch Sidebars From Without)');
+  andThen(function() {
+    assert.equal(document.activeElement, focused);
+  });
+});


### PR DESCRIPTION
Currently, if you have a component that attempts to shift focus on `didInsertElement`, and you wrap that component in a wormhole, it's possible for focus to be lost because the inner component's `didInsertElement` fires before ember-wormhole's, and focus is lost when reparenting DOM elements.

This PR ensures that the element that has focus prior to `appendToDestination` retains focus once the append operation is complete. Should resolve #22.