### PR TITLE
Better export for wormhole component.

### DIFF
--- a/app/components/ember-wormhole.js
+++ b/app/components/ember-wormhole.js
@@ -1,1 +1,2 @@
-export { default } from 'ember-wormhole/components/ember-wormhole';
+import Component from 'ember-wormhole/components/ember-wormhole';
+export default Component;


### PR DESCRIPTION
This fixes an issue I was having loading ember-wormhole (via ember-modal-dialog) on IE8 in development mode with `ember serve`.