### PR TITLE
Update ember-wormhole.js

### DIFF
--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -8,7 +8,13 @@ export default Ember.Component.extend({
   to: computed.alias('destinationElementId'),
   destinationElementId: null,
   destinationElement: computed('destinationElementId', 'renderInPlace', function() {
-    return this.get('renderInPlace') ? this.element : document.getElementById(this.get('destinationElementId'));
+    var destinationElementId;
+    if (this.get('renderInPlace')) {
+      return this.element;
+    } else {
+      destinationElementId = this.get('destinationElementId');
+      return destinationElementId instanceof HTMLElement ? destinationElementId : document.getElementById(destinationElementId);
+    }
   }),
   renderInPlace: false,
 


### PR DESCRIPTION
Allow user to pass html elements as the to= attribute. This reduces the necessity of having a global id which pollutes the global space