### PR TITLE
Update ember-wormhole.js to fix transpiler output for IE8

### DIFF
--- a/app/components/ember-wormhole.js
+++ b/app/components/ember-wormhole.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-wormhole/components/ember-wormhole';
+import EmberWormhole from 'ember-wormhole/components/ember-wormhole';
+
+export default EmberWormhole;


### PR DESCRIPTION
Hi

I noticed that when building with ember serve or ember build -dev, my application was not loading in IE8.

I traced it to a problem where IE8 does not like the transpiled output. As far as I know the change I have made is functionally equivalent, but for some reason babel.js creates slightly different output.

Previously, when performing a dev build, this file was being transpiled to: exports.default = ember_wormhole.default;
Now the file is transpiled to: exports['default'] = EmberWormhole['default'];
It now matches most other ember-cli addons and works in IE8.

I realize that eventually support for IE8 is going to go away but since Ember Wormhole works well with Ember 1 for now, it would be really helpful if this change could be made.