### PR TITLE
Update ember-code-snippet to ^1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-release": "^0.2.5",
     "ember-cli-sri": "^1.0.1",
     "ember-cli-uglify": "^1.0.1",
-    "ember-code-snippet": "1.1.0",
+    "ember-code-snippet": "^1.3.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",


### PR DESCRIPTION
Versions prior to 1.1.2 did not support npm v3.x.
See https://github.com/ef4/ember-code-snippet/pull/14

Running the ember-wormhole tests via `npm test` fails when using npm v3.
Updating ember-code-snippet fixes this.