### PR TITLE
Avoid bind-attr in tests for newer Ember

### DIFF
--- a/tests/dummy/app/components/x-favicon.js
+++ b/tests/dummy/app/components/x-favicon.js
@@ -1,8 +1,13 @@
 import Ember from "ember";
 import Wormhole from 'ember-wormhole/components/ember-wormhole';
 
+let [major, minor] = Ember.VERSION.split('.').map(n => parseInt(n, 10));
+let needsBindAttr = major === 1 && minor < 11;
+
 export default Wormhole.extend({
   destinationElement: Ember.computed(function () {
     return document.getElementsByTagName('head')[0];
-  })
+  }),
+
+  needsBindAttr
 });

--- a/tests/dummy/app/templates/components/x-favicon.hbs
+++ b/tests/dummy/app/templates/components/x-favicon.hbs
@@ -1,1 +1,7 @@
-<link rel="icon" {{bind-attr href=href}} />
+{{#if needsBindAttr}}
+  {{! Ember version 1.10 does not support direct bound attributes and
+      must use bind-attr. This causes a deprecation warning in Ember 1.13+ }}
+  <link rel="icon" {{bind-attr href=href}} />
+{{else}}
+  <link rel="icon" href={{href}} />
+{{/if}}


### PR DESCRIPTION
Ember 1.13 deprecated bind-attr, and Ember 2.0 removed it. This causes
the tests to fail in the ember-release, ember-beta and ember-canary
scenarios. The '1.10.1' scenario will fail if `bind-attr` is removed,
though. This modifies the `x-favicon.hbs` template to conditionally use
`bind-attr` only when it must.