### PR TITLE
Refactor to public APIs for head/tail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4.2"
 
 sudo: false
 
@@ -11,9 +11,9 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=1.10.1
-  - EMBER_TRY_SCENARIO=1.11.3
-  - EMBER_TRY_SCENARIO=1.12.1
+  - EMBER_TRY_SCENARIO=1.13.13
+  - EMBER_TRY_SCENARIO=2.0.3
+  - EMBER_TRY_SCENARIO=2.4.5
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -27,7 +27,7 @@ matrix:
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm@^3"
 
 install:
   - npm install -g bower

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Ember Wormhole [![Build Status](https://travis-ci.org/yapplabs/ember-wormhole.svg?branch=master)](https://travis-ci.org/yapplabs/ember-wormhole) [![Ember Observer Score](http://emberobserver.com/badges/ember-wormhole.svg)](http://emberobserver.com/addons/ember-wormhole)
 
-This ember-cli addon provides a component that allows for rendering a block 
-to a DOM element somewhere else on the page. The component retains typical Ember 
-context in terms of bound data and action handling.
+This ember-cli addon provides a component that allows for rendering a block
+to a DOM element somewhere else on the page. The component retains typical Ember
+context in terms of bound data and action handling. Ember Wormhole is
+compatible with [Ember FastBoot](http://www.ember-fastboot.com/) as of version
+0.4.0, so long as the destination element is part of Ember's own templates.
 
 ## Live Demo
 
@@ -15,12 +17,12 @@ a component but needs to render as a top-level DOM element, such as a confirmati
 
 ## And How?
 
-This component tracks its element's child nodes. When inserted into the DOM, it appends 
+This component tracks its element's child nodes. When inserted into the DOM, it appends
 its child nodes to a destination element elsewhere. When removed from the DOM, it
-removes its child nodes, so as not to orphan them on the other side of the wormhole. 
+removes its child nodes, so as not to orphan them on the other side of the wormhole.
 
-Nothing else changes -- data binding  and action bubbling still flow according to 
-the Ember component hierarchy. That includes usages of `yield`, so blocks provided 
+Nothing else changes -- data binding  and action bubbling still flow according to
+the Ember component hierarchy. That includes usages of `yield`, so blocks provided
 to `ember-wormhole` simply appear in another part of the DOM.
 
 ## Show Me Some Code!
@@ -71,7 +73,7 @@ and remove them when the route is exited.
 
 ## Can I Render In Place (i.e. Unwormhole)?
 
-Yes! Sometimes you feel like a wormhole. Sometimes you don't. Situations 
+Yes! Sometimes you feel like a wormhole. Sometimes you don't. Situations
 sometimes call for the same content to be rendered through the wormhole or in place.
 
 In this example, `renderInPlace` will override `to` and cause the wormhole content to be rendered in place.
@@ -87,6 +89,19 @@ This technique is useful for:
 - Presenting typically-wormholed content within a styleguide
 - Toggling content back and forth through the wormhole
 - Parlor tricks
+
+## What if if my element has no id?
+
+You can provide an element directly to the wormhole. For example:
+
+```hbs
+{{#ember-wormhole destinationElement=someElement}}
+  Hello world!
+{{/ember-wormhole}}
+```
+
+This usage may be appropriate when using wormhole with dynamic targets,
+such as rendering into all elements matching a selector.
 
 ## Development Setup
 

--- a/addon/templates/components/ember-wormhole.hbs
+++ b/addon/templates/components/ember-wormhole.hbs
@@ -1,3 +1,3 @@
 {{unbound _wormholeHeadNode ~}}
-<link rel="icon" href={{href}} />
+{{yield ~}}
 {{unbound _wormholeTailNode ~}}

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -1,0 +1,38 @@
+/*
+ * Implement some helpers methods for interacting with the DOM,
+ * be it Fastboot's SimpleDOM or a browser's version.
+ */
+
+export function getActiveElement() {
+  if (typeof document === 'undefined') {
+    return null;
+  } else {
+    return document.activeElement;
+  }
+}
+
+function childNodesOfElement(element) {
+  let children = [];
+  let child = element.firstChild;
+  while (child) {
+    children.push(child);
+    child = child.nextSibling;
+  }
+  return children;
+}
+
+export function findElementById(doc, id) {
+  let nodes = childNodesOfElement(doc);
+  let node;
+
+  while (nodes.length) {
+    node = nodes.shift();
+
+    if (node.getAttribute && node.getAttribute('id') === id) {
+      return node;
+    }
+
+    nodes = childNodesOfElement(node).concat(nodes);
+  }
+}
+

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-wormhole",
   "dependencies": {
-    "ember": "1.13.6",
+    "ember": "1.13.13",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -5,23 +5,21 @@ module.exports = {
       dependencies: { }
     },
     {
-      name: '1.10.1',
+      name: '1.13.13',
       dependencies: {
-        'ember': '1.10.1',
-        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
+        'ember': '1.13.13'
       }
     },
     {
-      name: '1.11.3',
+      name: '2.0.3',
       dependencies: {
-        'ember': '1.11.3',
-        'ember-load-initializers': 'ember-cli/ember-load-initializers#0.0.2'
+        'ember': '2.0.3'
       }
     },
     {
-      name: '1.12.1',
+      name: '2.4.5',
       dependencies: {
-        'ember': '1.12.1'
+        'ember': '2.4.5'
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-github-pages": "0.0.6",
-    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
@@ -44,7 +43,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-cli-htmlbars": "^1.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/acceptance/wormhole-test.js
+++ b/tests/acceptance/wormhole-test.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import run from 'ember-runloop';
+import set from 'ember-metal/set';
 import QUnit from 'qunit';
 import {
   module,
   test
 } from 'qunit';
 import startApp from 'dummy/tests/helpers/start-app';
-
-const { set } = Ember;
 
 var application;
 var assert = QUnit.assert;
@@ -21,12 +21,12 @@ assert.contentNotIn = function(sidebarId, content) {
 };
 
 module('Acceptance: Wormhole', {
-  beforeEach: function() {
+  beforeEach() {
     application = startApp();
   },
 
-  afterEach: function() {
-    Ember.run(application, 'destroy');
+  afterEach() {
+    run(application, 'destroy');
   }
 });
 
@@ -37,18 +37,18 @@ test('modal example', function(assert) {
   });
   click('button:contains(Toggle Modal)');
   andThen(function() {
-    assert.equal(Ember.$('#modals .overlay').length, 1, 'overlay is visible');
-    assert.equal(Ember.$('#modals .dialog').length, 1, 'dialog is visible');
+    assert.equal($('#modals .overlay').length, 1, 'overlay is visible');
+    assert.equal($('#modals .dialog').length, 1, 'dialog is visible');
   });
   click('#modals .overlay');
   andThen(function() {
-    assert.equal(Ember.$('#modals .overlay').length, 0, 'overlay is not visible');
-    assert.equal(Ember.$('#modals .dialog').length, 0, 'dialog is not visible');
+    assert.equal($('#modals .overlay').length, 0, 'overlay is not visible');
+    assert.equal($('#modals .dialog').length, 0, 'dialog is not visible');
   });
   fillIn('.username', 'coco');
   click('button:contains(Toggle Modal)');
   andThen(function() {
-    assert.equal(Ember.$('#modals .dialog p:contains(coco)').length, 1, 'up-to-date username is shown in dialog');
+    assert.equal($('#modals .dialog p:contains(coco)').length, 1, 'up-to-date username is shown in dialog');
   });
 });
 
@@ -63,9 +63,9 @@ test('sidebar example', function(assert) {
   });
   click('button:contains(Toggle Sidebar Content)');
   andThen(function() {
-    sidebarWormhole = Ember.$('#sidebarWormhole').data('ember-wormhole');
-    sidebarFirstNode1 = sidebarWormhole._firstNode;
-    header1 = Ember.$('#sidebar h1');
+    sidebarWormhole = $('#sidebarWormhole').data('ember-wormhole');
+    sidebarFirstNode1 = sidebarWormhole._wormholeHeadNode;
+    header1 = $('#sidebar h1');
     assert.contentIn('sidebar');
   });
   fillIn('.first-name', 'Ray');
@@ -75,8 +75,8 @@ test('sidebar example', function(assert) {
   });
   click('#sidebar button:contains(Switch)');
   andThen(function() {
-    sidebarFirstNode2 = sidebarWormhole._firstNode;
-    header2 = Ember.$('#othersidebar h1');
+    sidebarFirstNode2 = sidebarWormhole._wormholeHeadNode;
+    header2 = $('#othersidebar h1');
     assert.equal(header1.text(), header2.text(), 'same header text');
     assert.ok(header1.is(header2), 'same header elements'); // appended elsewhere
     assert.ok(sidebarFirstNode1.isSameNode(sidebarFirstNode2), 'different first nodes'); // appended elsewhere
@@ -140,8 +140,8 @@ test('survives rerender', function(assert) {
 
   click('button:contains(Toggle Sidebar Content)');
   andThen(function() {
-    sidebarWormhole = Ember.$('#sidebarWormhole').data('ember-wormhole');
-    header1 = Ember.$('#sidebar h1');
+    sidebarWormhole = $('#sidebarWormhole').data('ember-wormhole');
+    header1 = $('#sidebar h1');
     assert.contentIn('sidebar');
   });
 
@@ -156,7 +156,7 @@ test('survives rerender', function(assert) {
   });
 
   andThen(function() {
-    header2 = Ember.$('#sidebar h1');
+    header2 = $('#sidebar h1');
     assert.contentIn('sidebar', 'p:contains(Ringo Starr)');
     assert.equal(header1.text(), header2.text(), 'same header text');
   });
@@ -165,10 +165,10 @@ test('survives rerender', function(assert) {
 test('throws if destination element not in DOM', function(assert) {
   visit('/');
   andThen(function() {
-    Ember.$('#sidebar').remove();
+    $('#sidebar').remove();
   });
   var wormholeToMissingSidebar = function() {
-    Ember.$('button:contains(Toggle Sidebar Content)').click();
+    $('button:contains(Toggle Sidebar Content)').click();
   };
   andThen(function() {
     assert.throws(
@@ -183,7 +183,7 @@ test('throws if destination element id falsy', function(assert) {
   visit('/');
   var wormholeToNowhere = function() {
     application.__container__.lookup('controller:application').set('sidebarId', null);
-    Ember.$('button:contains(Toggle Sidebar Content)').click();
+    $('button:contains(Toggle Sidebar Content)').click();
   };
   andThen(function() {
     assert.throws(
@@ -203,10 +203,10 @@ test('preserves focus', function (assert) {
   });
   click('button:contains(Toggle Sidebar Content)');
   andThen(function() {
-    sidebarWormhole = Ember.$('#sidebarWormhole').data('ember-wormhole');
+    sidebarWormhole = $('#sidebarWormhole').data('ember-wormhole');
     assert.contentIn('sidebar');
     assert.contentNotIn('othersidebar');
-    Ember.$('button:contains(Hide Sidebar Content)').focus();
+    $('button:contains(Hide Sidebar Content)').focus();
     focused = document.activeElement;
   });
   andThen(function() {

--- a/tests/dummy/app/components/x-favicon.js
+++ b/tests/dummy/app/components/x-favicon.js
@@ -1,10 +1,12 @@
 import Ember from "ember";
 import Wormhole from 'ember-wormhole/components/ember-wormhole';
+import layout from '../templates/components/x-favicon';
 
 let [major, minor] = Ember.VERSION.split('.').map(n => parseInt(n, 10));
 let needsBindAttr = major === 1 && minor < 11;
 
 export default Wormhole.extend({
+  layout,
   destinationElement: Ember.computed(function () {
     return document.getElementsByTagName('head')[0];
   }),


### PR DESCRIPTION
In the template for ember-wormhole, use helpers that register an element to the parent wormhole component. The wormhole component can then use those elements to move to the target. This lessens the private APIs used by wormhole, but still uses private APIs to access the DOM or Fastboot SimpleDOM based on where the code is running. This could use all private API if we made SimpleDOM a dependency, but that would just inflate the JS payload with little benefit.

This unblocks Fastboot rendering. It will also mean dropping support for Ember versions before 1.13. See https://github.com/yapplabs/ember-wormhole/issues/47 for discussion.

TODO:

* [x] Remove support for Ember pre-1.13
* [x] Check for `isDestroyed` in the `afterRender` callback.
* [x] Document Fastboot status
* [x] Document/test passing a bare element to `destinationElement`
* [x] Move SimpleDOM/DOM compat tooling to a util module
* [ ] ~~Document subclassing of the wormhole component class~~ skipping this, but after merge and release I will open an issue/PR on the x-favicon repo