### PR TITLE
Remove `needsBindAttr` from x-favicon component in tests

### DIFF
--- a/tests/dummy/app/components/x-favicon.js
+++ b/tests/dummy/app/components/x-favicon.js
@@ -2,14 +2,9 @@ import Ember from "ember";
 import Wormhole from 'ember-wormhole/components/ember-wormhole';
 import layout from '../templates/components/x-favicon';
 
-let [major, minor] = Ember.VERSION.split('.').map(n => parseInt(n, 10));
-let needsBindAttr = major === 1 && minor < 11;
-
 export default Wormhole.extend({
   layout,
   destinationElement: Ember.computed(function () {
     return document.getElementsByTagName('head')[0];
-  }),
-
-  needsBindAttr
+  })
 });


### PR DESCRIPTION
The tests no longer support Ember before 1.13, so this hack is no
longer necessary.