### PR TITLE
Fix initializer arity deprecation

### DIFF
--- a/tests/dummy/app/initializers/add-modals-element.js
+++ b/tests/dummy/app/initializers/add-modals-element.js
@@ -1,5 +1,8 @@
 /*globals document*/
-function initialize(container, application){
+function initialize(){
+  // In Ember 2.x, initialize is called only with `application` instead of `(container, application)`
+  // See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
+  var application = arguments[1] || arguments[0];
   var rootEl = document.querySelector(application.rootElement);
   var modalContainerEl = document.createElement('div');
   var modalContainerElId = 'modals';


### PR DESCRIPTION
When running the tests for Ember 2.x scenarios, there was a deprecation
warning due to the dummy app using an initializer with arity two
(`initialize(container, application)` instead of `initialize(application)`).
This changes initialize so that it will not trigger the deprecation warning.
See: http://emberjs.com/deprecations/v2.x/#toc_initializer-arity