### PR TITLE
Test ember-alpha in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,14 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-alpha
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-alpha
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -48,6 +48,15 @@ module.exports = {
       resolutions: {
         'ember': 'canary'
       }
+    },
+    {
+      name: 'ember-alpha',
+      dependencies: {
+        'ember': 'alpha'
+      },
+      resolutions: {
+        'ember': 'alpha'
+      }
     }
   ]
 };

--- a/tests/dummy/app/components/document-title.js
+++ b/tests/dummy/app/components/document-title.js
@@ -16,7 +16,7 @@ export default Wormhole.extend({
     return document.getElementsByTagName('title')[0];
   }),
 
-  willClearRender: function () {
+  willDestroyElement: function () {
     titles.removeObject(this);
     this._super.apply(this, arguments);
   }


### PR DESCRIPTION
Also tweaked a test to use `willDestroyElement` instead of `willClearRender` (after discovering that the glimmer renderer wasn't calling the hook). I submitted https://github.com/emberjs/ember.js/pull/14090 to fix that upstream, but it seems good to change our usage also (since `willClearRender` doesn't make conceptual sense any longer).