### PR TITLE
Use native doc.getElementById when available

### DIFF
--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -22,6 +22,10 @@ function childNodesOfElement(element) {
 }
 
 export function findElementById(doc, id) {
+  if (doc.getElementById) {
+    return doc.getElementById(id);
+  }
+
   let nodes = childNodesOfElement(doc);
   let node;
 


### PR DESCRIPTION
SimpleDOM doesn't have `getElementById`, but in a browser it is
more efficient to use the native `getElementById` instead of walking the
dom.