### PR TITLE
Use `getDOM` util to get dom reference in glimmer2

### DIFF
--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import layout from '../templates/components/ember-wormhole';
 import {
   getActiveElement,
-  findElementById
+  findElementById,
+  getDOM
 } from '../utils/dom';
 
 const { Component, computed, observer, run } = Ember;
@@ -34,9 +35,7 @@ export default Component.extend({
   init() {
     this._super(...arguments);
 
-    // Private Ember API usage. Get the dom implementation used by the current
-    // renderer, be it native browser DOM or Fastboot SimpleDOM
-    this._dom = this.renderer._dom;
+    this._dom = getDOM(this);
 
     // Create text nodes used for the head, tail
     this._wormholeHeadNode = this._dom.document.createTextNode('');

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -1,6 +1,6 @@
 /*
  * Implement some helpers methods for interacting with the DOM,
- * be it Fastboot's SimpleDOM or a browser's version.
+ * be it Fastboot's SimpleDOM or the browser's version.
  */
 
 export function getActiveElement() {
@@ -40,3 +40,15 @@ export function findElementById(doc, id) {
   }
 }
 
+// Private Ember API usage. Get the dom implementation used by the current
+// renderer, be it native browser DOM or Fastboot SimpleDOM
+export function getDOM(context) {
+  let { renderer } = context;
+  if (renderer._dom) { // pre glimmer2
+    return renderer._dom;
+  } else if (renderer._env && renderer._env.getDOM) { // glimmer2
+    return renderer._env.getDOM();
+  } else {
+    throw new Error('ember-wormhole could not get DOM');
+  }
+}


### PR DESCRIPTION
When using ember canary (2.9.x), the `this.renderer._dom` property no
longer exists. This adds a util function to get access to the `dom`
property in a way that works in both contexts.

This makes it so ember-wormhole works correctly in ember canary 2.9.x when rendered in the browser, but there are some issues with ember-cli-fastboot
and ember canary (https://github.com/ember-fastboot/ember-cli-fastboot/issues/258 and https://github.com/ember-fastboot/ember-cli-fastboot/issues/255) that are not related to ember-wormhole. The code in this PR will work with ember canary and fastboot after those issues are resolved.

Fixes #64