### PR TITLE
Support for passing DOM element instead of String ID

### DIFF
--- a/addon/components/ember-wormhole.js
+++ b/addon/components/ember-wormhole.js
@@ -21,11 +21,16 @@ export default Component.extend({
     if (renderInPlace) {
       return this._element;
     }
-    let id = this.get('destinationElementId');
-    if (!id) {
+    let target = this.get('destinationElementId');
+    if (!target) {
       return null;
     }
-    return findElementById(this._dom, id);
+
+    if(typeof target === 'object') {
+      return target;
+    } else {
+      return findElementById(this._dom, target);
+    }
   }),
   renderInPlace: false,
 


### PR DESCRIPTION
Give possibility for passing target DOM element where ember-wormhole should render its content alongside with element ID.