### PR TITLE
Fix getDOM for Ember 2.6/2.7 in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=2.6
+  - EMBER_TRY_SCENARIO=2.7
   - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/utils/dom.js
+++ b/addon/utils/dom.js
@@ -46,12 +46,15 @@ export function findElementById(doc, id) {
 // Private Ember API usage. Get the dom implementation used by the current
 // renderer, be it native browser DOM or Fastboot SimpleDOM
 export function getDOM(context) {
-  let container = getOwner ? getOwner(context) : context.container;
-  let documentService = container.lookup('service:-document');
+  let { renderer } = context;
+  if (!renderer._dom) { // pre glimmer2
+    let container = getOwner ? getOwner(context) : context.container;
+    let documentService = container.lookup('service:-document');
 
-  if (documentService) { return documentService; }
+    if (documentService) { return documentService; }
 
-  let renderer = container.lookup('renderer:-dom');
+    renderer = container.lookup('renderer:-dom');
+  }
 
   if (renderer._dom && renderer._dom.document) { // pre Ember 2.6
     return renderer._dom.document;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -24,6 +24,18 @@ module.exports = {
       }
     },
     {
+      name: '2.6',
+      dependencies: {
+        'ember': '~2.6.0'
+      }
+    },
+    {
+      name: '2.7',
+      dependencies: {
+        'ember': '~2.7.0'
+      }
+    },
+    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
@@ -37,6 +49,18 @@ module.exports = {
         devDependencies: {
           'ember-source': null
         }
+      }
+    },
+    {
+      name: '2.12',
+      dependencies: {
+        'ember': '~2.12.0'
+      }
+    },
+    {
+      name: '2.12',
+      dependencies: {
+        'ember': '~2.12.0'
       }
     },
     {

--- a/tests/integration/components/ember-wormhole-test.js
+++ b/tests/integration/components/ember-wormhole-test.js
@@ -1,0 +1,21 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('ember-wormhole', 'Integration | Component | ember wormhole', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  // Template block usage:
+  this.render(hbs`
+    <div id="wormhole"></div>
+    {{#ember-wormhole to="wormhole"}}
+      template block text
+    {{/ember-wormhole}}
+  `);
+
+  assert.equal(this.$('#wormhole').text().trim(), 'template block text');
+});


### PR DESCRIPTION
This addresses #77. The exception mentioned there came up in integration tests. As there were no integration tests here, this was not catched. Added a simple one, and indeed that was failing for Ember 2.6/2.7 with the mentioned exception!

The change here reverts the `getDOM` function to use the same code that was used in 0.4.1 (the last working version that was not affected by #77) for pre Glimmer2 versions of Ember, while using the newer code path introduced in 0.5.x for Glimmer2 apps (using the `-document` service).

This PR includes #94, so merge that first! 